### PR TITLE
SSUTO-2 Feat: User Account Creation

### DIFF
--- a/src/main/java/com/ss/utopia/auth/UtopiaAuthServiceApplication.java
+++ b/src/main/java/com/ss/utopia/auth/UtopiaAuthServiceApplication.java
@@ -2,6 +2,8 @@ package com.ss.utopia.auth;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @SpringBootApplication
 public class UtopiaAuthServiceApplication {
@@ -10,4 +12,8 @@ public class UtopiaAuthServiceApplication {
     SpringApplication.run(UtopiaAuthServiceApplication.class, args);
   }
 
+  @Bean
+  public BCryptPasswordEncoder bCryptPasswordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
 }

--- a/src/main/java/com/ss/utopia/auth/config/Constants.java
+++ b/src/main/java/com/ss/utopia/auth/config/Constants.java
@@ -1,0 +1,6 @@
+package com.ss.utopia.auth.config;
+
+public class Constants {
+  //todo load from properties file
+  public static final String API_V_0_1_ACCOUNTS = "/api/v0.1/accounts";
+}

--- a/src/main/java/com/ss/utopia/auth/config/SecurityConfig.java
+++ b/src/main/java/com/ss/utopia/auth/config/SecurityConfig.java
@@ -1,0 +1,29 @@
+package com.ss.utopia.auth.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SecurityConfig.class);
+
+  @Override
+  protected void configure(HttpSecurity http) throws Exception {
+    http
+        .cors().and().csrf().disable()
+        .authorizeRequests()
+        .antMatchers(HttpMethod.POST, Constants.API_V_0_1_ACCOUNTS).permitAll()
+        .anyRequest().authenticated()
+        .and()
+        .formLogin()
+        .and()
+        .httpBasic();
+  }
+}

--- a/src/main/java/com/ss/utopia/auth/controller/UserAccountController.java
+++ b/src/main/java/com/ss/utopia/auth/controller/UserAccountController.java
@@ -26,9 +26,10 @@ public class UserAccountController {
   }
 
   @PostMapping(consumes = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
-  public ResponseEntity<Long> createAccount(@Valid @RequestBody CreateUserAccountDto createUserAccountDto) {
+  public ResponseEntity<Long> createNewAccount(@Valid @RequestBody CreateUserAccountDto createUserAccountDto) {
     LOGGER.info("POST accounts");
-    var userId = service.create(createUserAccountDto);
+    var userAccount = service.createNewAccount(createUserAccountDto);
+    var userId = userAccount.getId();
     var uri = URI.create(Constants.API_V_0_1_ACCOUNTS + "/" + userId);
     return ResponseEntity.created(uri).build();
   }

--- a/src/main/java/com/ss/utopia/auth/controller/UserAccountController.java
+++ b/src/main/java/com/ss/utopia/auth/controller/UserAccountController.java
@@ -31,6 +31,6 @@ public class UserAccountController {
     var userAccount = userAccountService.createNewAccount(createUserAccountDto);
     var userId = userAccount.getId();
     var uri = URI.create(Constants.API_V_0_1_ACCOUNTS + "/" + userId);
-    return ResponseEntity.created(uri).build();
+    return ResponseEntity.created(uri).body(userId);
   }
 }

--- a/src/main/java/com/ss/utopia/auth/controller/UserAccountController.java
+++ b/src/main/java/com/ss/utopia/auth/controller/UserAccountController.java
@@ -1,0 +1,35 @@
+package com.ss.utopia.auth.controller;
+
+import com.ss.utopia.auth.config.Constants;
+import com.ss.utopia.auth.dto.CreateUserAccountDto;
+import com.ss.utopia.auth.service.UserAccountService;
+import java.net.URI;
+import javax.validation.Valid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(Constants.API_V_0_1_ACCOUNTS)
+public class UserAccountController {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(UserAccountController.class);
+  private final UserAccountService service;
+
+  public UserAccountController(UserAccountService service) {
+    this.service = service;
+  }
+
+  @PostMapping(consumes = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
+  public ResponseEntity<Long> createAccount(@Valid @RequestBody CreateUserAccountDto createUserAccountDto) {
+    LOGGER.info("POST accounts");
+    var userId = service.create(createUserAccountDto);
+    var uri = URI.create(Constants.API_V_0_1_ACCOUNTS + "/" + userId);
+    return ResponseEntity.created(uri).build();
+  }
+}

--- a/src/main/java/com/ss/utopia/auth/controller/UserAccountController.java
+++ b/src/main/java/com/ss/utopia/auth/controller/UserAccountController.java
@@ -4,6 +4,7 @@ import com.ss.utopia.auth.config.Constants;
 import com.ss.utopia.auth.dto.CreateUserAccountDto;
 import com.ss.utopia.auth.service.UserAccountService;
 import java.net.URI;
+import java.util.UUID;
 import javax.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,7 +27,7 @@ public class UserAccountController {
   }
 
   @PostMapping(consumes = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
-  public ResponseEntity<Long> createNewAccount(@Valid @RequestBody CreateUserAccountDto createUserAccountDto) {
+  public ResponseEntity<UUID> createNewAccount(@Valid @RequestBody CreateUserAccountDto createUserAccountDto) {
     LOGGER.info("POST accounts");
     var userAccount = userAccountService.createNewAccount(createUserAccountDto);
     var userId = userAccount.getId();

--- a/src/main/java/com/ss/utopia/auth/controller/UserAccountController.java
+++ b/src/main/java/com/ss/utopia/auth/controller/UserAccountController.java
@@ -19,16 +19,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserAccountController {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UserAccountController.class);
-  private final UserAccountService service;
+  private final UserAccountService userAccountService;
 
-  public UserAccountController(UserAccountService service) {
-    this.service = service;
+  public UserAccountController(UserAccountService userAccountService) {
+    this.userAccountService = userAccountService;
   }
 
   @PostMapping(consumes = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<Long> createNewAccount(@Valid @RequestBody CreateUserAccountDto createUserAccountDto) {
     LOGGER.info("POST accounts");
-    var userAccount = service.createNewAccount(createUserAccountDto);
+    var userAccount = userAccountService.createNewAccount(createUserAccountDto);
     var userId = userAccount.getId();
     var uri = URI.create(Constants.API_V_0_1_ACCOUNTS + "/" + userId);
     return ResponseEntity.created(uri).build();

--- a/src/main/java/com/ss/utopia/auth/controller/UserAccountController.java
+++ b/src/main/java/com/ss/utopia/auth/controller/UserAccountController.java
@@ -1,0 +1,41 @@
+package com.ss.utopia.auth.controller;
+
+import com.ss.utopia.auth.config.Constants;
+import com.ss.utopia.auth.dto.CreateUserAccountDto;
+import com.ss.utopia.auth.service.UserAccountService;
+import java.net.URI;
+import javax.validation.Valid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(Constants.API_V_0_1_ACCOUNTS)
+public class UserAccountController {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(UserAccountController.class);
+  private final UserAccountService service;
+
+  public UserAccountController(UserAccountService service) {
+    this.service = service;
+  }
+
+  @GetMapping
+  public String get() {
+    return "Pass";
+  }
+
+  @PostMapping(consumes = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
+  public ResponseEntity<Long> createAccount(@Valid @RequestBody CreateUserAccountDto createUserAccountDto) {
+    LOGGER.info("POST accounts");
+    var userId = service.create(createUserAccountDto);
+    var uri = URI.create(Constants.API_V_0_1_ACCOUNTS + "/" + userId);
+    return ResponseEntity.created(uri).build();
+  }
+}

--- a/src/main/java/com/ss/utopia/auth/dto/CreateUserAccountDto.java
+++ b/src/main/java/com/ss/utopia/auth/dto/CreateUserAccountDto.java
@@ -1,0 +1,34 @@
+package com.ss.utopia.auth.dto;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+@AllArgsConstructor
+public class CreateUserAccountDto {
+
+  public static final String REGEX = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*-_=+,.?])[A-Za-z\\d!@#$%^&*-_=+,.?]{10,128}$";
+  public static final String REGEX_MSG = "Password must be between 10 and 128 characters,"
+      + " contain at least one lowercase letter,"
+      + " at least one uppercase letter,"
+      + " at least one number,"
+      + " and at least one special character from the following: !@#$%^&*-_=+,.?";
+
+  @NotNull
+  @NotBlank(message = "Email cannot be blank.")
+  @Email(message = "Email must be valid.")
+  private String email;
+
+  @ToString.Exclude
+  @NotNull
+  @NotBlank(message = "Password cannot be blank.")
+  @Size(min = 10, max = 128, message = "Length must be between 10 and 128 characters.")
+  @Pattern(regexp = REGEX, message = REGEX_MSG)
+  private String password;
+}

--- a/src/main/java/com/ss/utopia/auth/dto/CreateUserAccountDto.java
+++ b/src/main/java/com/ss/utopia/auth/dto/CreateUserAccountDto.java
@@ -6,11 +6,15 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class CreateUserAccountDto {
 
   public static final String REGEX = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*-_=+,.?])[A-Za-z\\d!@#$%^&*-_=+,.?]{10,128}$";

--- a/src/main/java/com/ss/utopia/auth/entity/UserAccount.java
+++ b/src/main/java/com/ss/utopia/auth/entity/UserAccount.java
@@ -1,0 +1,41 @@
+package com.ss.utopia.auth.entity;
+
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserAccount {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private Long id;
+
+  @NotBlank
+  @Email
+  private String email;
+
+  @ToString.Exclude
+  @EqualsAndHashCode.Exclude
+  @NotBlank
+  private String hashedPassword;
+
+  @EqualsAndHashCode.Exclude
+  @OneToMany
+  private List<UserRole> roles;
+}

--- a/src/main/java/com/ss/utopia/auth/entity/UserAccount.java
+++ b/src/main/java/com/ss/utopia/auth/entity/UserAccount.java
@@ -1,13 +1,15 @@
 package com.ss.utopia.auth.entity;
 
-import java.util.List;
+import java.time.ZonedDateTime;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -35,7 +37,12 @@ public class UserAccount {
   @NotBlank
   private String hashedPassword;
 
+  @NotNull
   @EqualsAndHashCode.Exclude
-  @OneToMany
-  private List<UserRole> roles;
+  private ZonedDateTime creationDateTime = ZonedDateTime.now();
+
+  private boolean isConfirmed = false;
+
+  @Enumerated(EnumType.STRING)
+  private UserRole userRole = UserRole.DEFAULT;
 }

--- a/src/main/java/com/ss/utopia/auth/entity/UserAccount.java
+++ b/src/main/java/com/ss/utopia/auth/entity/UserAccount.java
@@ -1,6 +1,7 @@
 package com.ss.utopia.auth.entity;
 
 import java.time.ZonedDateTime;
+import java.util.UUID;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -26,7 +27,7 @@ public class UserAccount {
 
   @Id
   @GeneratedValue(strategy = GenerationType.AUTO)
-  private Long id;
+  private UUID id;
 
   @NotBlank
   @Email

--- a/src/main/java/com/ss/utopia/auth/entity/UserRole.java
+++ b/src/main/java/com/ss/utopia/auth/entity/UserRole.java
@@ -1,25 +1,15 @@
 package com.ss.utopia.auth.entity;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+public enum UserRole {
+  DEFAULT("DEFAULT");
 
-@Entity
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
-public class UserRole {
+  private final String roleName;
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
-  private Long id;
+  UserRole(String roleName) {
+    this.roleName = roleName;
+  }
 
-  private String name;
-  private String description;
+  public String getRoleName() {
+    return roleName;
+  }
 }

--- a/src/main/java/com/ss/utopia/auth/entity/UserRole.java
+++ b/src/main/java/com/ss/utopia/auth/entity/UserRole.java
@@ -1,7 +1,11 @@
 package com.ss.utopia.auth.entity;
 
 public enum UserRole {
-  DEFAULT("DEFAULT");
+  DEFAULT("DEFAULT"),
+  CUSTOMER("CUSTOMER"),
+  TRAVEL_AGENT("TRAVEL_AGENT"),
+  EMPLOYEE("EMPLOYEE"),
+  ADMIN("ADMIN");
 
   private final String roleName;
 

--- a/src/main/java/com/ss/utopia/auth/entity/UserRole.java
+++ b/src/main/java/com/ss/utopia/auth/entity/UserRole.java
@@ -1,0 +1,25 @@
+package com.ss.utopia.auth.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserRole {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private Long id;
+
+  private String name;
+  private String description;
+}

--- a/src/main/java/com/ss/utopia/auth/exception/DuplicateEmailException.java
+++ b/src/main/java/com/ss/utopia/auth/exception/DuplicateEmailException.java
@@ -1,0 +1,18 @@
+package com.ss.utopia.auth.exception;
+
+import org.springframework.dao.DuplicateKeyException;
+
+public class DuplicateEmailException extends DuplicateKeyException {
+
+  private final String email;
+
+  public DuplicateEmailException(String email) {
+    super("An account with the email '" + email + "' already exists.");
+    this.email = email;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+}
+

--- a/src/main/java/com/ss/utopia/auth/exception/ExceptionControllerAdvisor.java
+++ b/src/main/java/com/ss/utopia/auth/exception/ExceptionControllerAdvisor.java
@@ -1,7 +1,13 @@
 package com.ss.utopia.auth.exception;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -9,11 +15,45 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class ExceptionControllerAdvisor {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionControllerAdvisor.class);
+
+
   @ResponseStatus(HttpStatus.CONFLICT)
   @ExceptionHandler(DuplicateEmailException.class)
   public Map<String, Object> duplicateEmailException(DuplicateEmailException ex) {
+    LOGGER.error(ex.getMessage());
+
     return Map.of("error", "duplicate email, account already exists.",
                   "email", ex.getEmail());
   }
 
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public Map<String, Object> handleValidationExceptions(MethodArgumentNotValidException ex) {
+    LOGGER.error(ex.getMessage());
+
+    var response = new HashMap<String, Object>();
+
+    response.put("error", "Invalid field(s) in request.");
+    response.put("status", 400);
+
+    // get field name and error message as map
+    var errors = ex.getBindingResult()
+        .getAllErrors()
+        .stream()
+        .collect(
+            Collectors.toMap(error -> ((FieldError) error).getField(),
+                             error -> getErrorMessageOrDefault((FieldError) error)));
+
+    response.put("message", errors);
+    return response;
+  }
+
+  private String getErrorMessageOrDefault(FieldError error) {
+    var msg = error.getDefaultMessage();
+    msg = msg == null || msg.isBlank() ? "Unknown validation failure." : msg;
+
+    LOGGER.debug("Field" + error.getField() + " Message: " + msg);
+    return msg;
+  }
 }

--- a/src/main/java/com/ss/utopia/auth/exception/ExceptionControllerAdvisor.java
+++ b/src/main/java/com/ss/utopia/auth/exception/ExceptionControllerAdvisor.java
@@ -1,0 +1,19 @@
+package com.ss.utopia.auth.exception;
+
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ExceptionControllerAdvisor {
+
+  @ResponseStatus(HttpStatus.CONFLICT)
+  @ExceptionHandler(DuplicateEmailException.class)
+  public Map<String, Object> duplicateEmailException(DuplicateEmailException ex) {
+    return Map.of("error", "duplicate email, account already exists.",
+                  "email", ex.getEmail());
+  }
+
+}

--- a/src/main/java/com/ss/utopia/auth/repository/UserAccountRepository.java
+++ b/src/main/java/com/ss/utopia/auth/repository/UserAccountRepository.java
@@ -2,11 +2,12 @@ package com.ss.utopia.auth.repository;
 
 import com.ss.utopia.auth.entity.UserAccount;
 import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UserAccountRepository extends JpaRepository<UserAccount, Long> {
+public interface UserAccountRepository extends JpaRepository<UserAccount, UUID> {
 
   Optional<UserAccount> findByEmail(String email);
 }

--- a/src/main/java/com/ss/utopia/auth/repository/UserAccountRepository.java
+++ b/src/main/java/com/ss/utopia/auth/repository/UserAccountRepository.java
@@ -1,0 +1,12 @@
+package com.ss.utopia.auth.repository;
+
+import com.ss.utopia.auth.entity.UserAccount;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserAccountRepository extends JpaRepository<UserAccount, Long> {
+
+  Optional<UserAccount> findByEmail(String email);
+}

--- a/src/main/java/com/ss/utopia/auth/service/UserAccountService.java
+++ b/src/main/java/com/ss/utopia/auth/service/UserAccountService.java
@@ -1,8 +1,9 @@
 package com.ss.utopia.auth.service;
 
 import com.ss.utopia.auth.dto.CreateUserAccountDto;
+import com.ss.utopia.auth.entity.UserAccount;
 
 public interface UserAccountService {
 
-  Long create(CreateUserAccountDto createUserAccountDto);
+  UserAccount createNewAccount(CreateUserAccountDto createUserAccountDto);
 }

--- a/src/main/java/com/ss/utopia/auth/service/UserAccountService.java
+++ b/src/main/java/com/ss/utopia/auth/service/UserAccountService.java
@@ -1,0 +1,8 @@
+package com.ss.utopia.auth.service;
+
+import com.ss.utopia.auth.dto.CreateUserAccountDto;
+
+public interface UserAccountService {
+
+  Long create(CreateUserAccountDto createUserAccountDto);
+}

--- a/src/main/java/com/ss/utopia/auth/service/UserAccountServiceImpl.java
+++ b/src/main/java/com/ss/utopia/auth/service/UserAccountServiceImpl.java
@@ -2,8 +2,12 @@ package com.ss.utopia.auth.service;
 
 import com.ss.utopia.auth.dto.CreateUserAccountDto;
 import com.ss.utopia.auth.entity.UserAccount;
+import com.ss.utopia.auth.entity.UserRole;
 import com.ss.utopia.auth.exception.DuplicateEmailException;
 import com.ss.utopia.auth.repository.UserAccountRepository;
+import java.time.ZonedDateTime;
+import javax.validation.Validation;
+import javax.validation.Validator;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -12,6 +16,7 @@ public class UserAccountServiceImpl implements UserAccountService {
 
   private final UserAccountRepository repository;
   private final BCryptPasswordEncoder passwordEncoder;
+  private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
   public UserAccountServiceImpl(UserAccountRepository repository,
                                 BCryptPasswordEncoder passwordEncoder) {
@@ -20,7 +25,9 @@ public class UserAccountServiceImpl implements UserAccountService {
   }
 
   @Override
-  public Long create(CreateUserAccountDto createUserAccountDto) {
+  public UserAccount createNewAccount(CreateUserAccountDto createUserAccountDto) {
+    validateDto(createUserAccountDto);
+
     repository.findByEmail(createUserAccountDto.getEmail())
         .ifPresent(userAccount -> {
           throw new DuplicateEmailException(createUserAccountDto.getEmail());
@@ -29,9 +36,19 @@ public class UserAccountServiceImpl implements UserAccountService {
     var account = UserAccount.builder()
         .email(createUserAccountDto.getEmail())
         .hashedPassword(passwordEncoder.encode(createUserAccountDto.getPassword()))
+        .creationDateTime(ZonedDateTime.now())
+        .isConfirmed(false)
+        .userRole(UserRole.DEFAULT)
         .build();
 
-    var createdAccount = repository.save(account);
-    return createdAccount.getId();
+    return repository.save(account);
+  }
+
+  private void validateDto(CreateUserAccountDto dto) {
+    var violations = validator.validate(dto);
+
+    if (!violations.isEmpty()) {
+      throw new IllegalArgumentException("Invalid DTO " + dto);
+    }
   }
 }

--- a/src/main/java/com/ss/utopia/auth/service/UserAccountServiceImpl.java
+++ b/src/main/java/com/ss/utopia/auth/service/UserAccountServiceImpl.java
@@ -1,0 +1,37 @@
+package com.ss.utopia.auth.service;
+
+import com.ss.utopia.auth.dto.CreateUserAccountDto;
+import com.ss.utopia.auth.entity.UserAccount;
+import com.ss.utopia.auth.exception.DuplicateEmailException;
+import com.ss.utopia.auth.repository.UserAccountRepository;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserAccountServiceImpl implements UserAccountService {
+
+  private final UserAccountRepository repository;
+  private final BCryptPasswordEncoder passwordEncoder;
+
+  public UserAccountServiceImpl(UserAccountRepository repository,
+                                BCryptPasswordEncoder passwordEncoder) {
+    this.repository = repository;
+    this.passwordEncoder = passwordEncoder;
+  }
+
+  @Override
+  public Long create(CreateUserAccountDto createUserAccountDto) {
+    repository.findByEmail(createUserAccountDto.getEmail())
+        .ifPresent(userAccount -> {
+          throw new DuplicateEmailException(createUserAccountDto.getEmail());
+        });
+
+    var account = UserAccount.builder()
+        .email(createUserAccountDto.getEmail())
+        .hashedPassword(passwordEncoder.encode(createUserAccountDto.getPassword()))
+        .build();
+
+    var createdAccount = repository.save(account);
+    return createdAccount.getId();
+  }
+}

--- a/src/main/java/com/ss/utopia/auth/service/UserAccountServiceImpl.java
+++ b/src/main/java/com/ss/utopia/auth/service/UserAccountServiceImpl.java
@@ -14,13 +14,13 @@ import org.springframework.stereotype.Service;
 @Service
 public class UserAccountServiceImpl implements UserAccountService {
 
-  private final UserAccountRepository repository;
+  private final UserAccountRepository userAccountRepository;
   private final BCryptPasswordEncoder passwordEncoder;
   private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
-  public UserAccountServiceImpl(UserAccountRepository repository,
+  public UserAccountServiceImpl(UserAccountRepository userAccountRepository,
                                 BCryptPasswordEncoder passwordEncoder) {
-    this.repository = repository;
+    this.userAccountRepository = userAccountRepository;
     this.passwordEncoder = passwordEncoder;
   }
 
@@ -28,7 +28,7 @@ public class UserAccountServiceImpl implements UserAccountService {
   public UserAccount createNewAccount(CreateUserAccountDto createUserAccountDto) {
     validateDto(createUserAccountDto);
 
-    repository.findByEmail(createUserAccountDto.getEmail())
+    userAccountRepository.findByEmail(createUserAccountDto.getEmail())
         .ifPresent(userAccount -> {
           throw new DuplicateEmailException(createUserAccountDto.getEmail());
         });
@@ -41,7 +41,7 @@ public class UserAccountServiceImpl implements UserAccountService {
         .userRole(UserRole.DEFAULT)
         .build();
 
-    return repository.save(account);
+    return userAccountRepository.save(account);
   }
 
   private void validateDto(CreateUserAccountDto dto) {

--- a/src/test/java/com/ss/utopia/auth/controller/UserAccountControllerTest.java
+++ b/src/test/java/com/ss/utopia/auth/controller/UserAccountControllerTest.java
@@ -1,0 +1,86 @@
+package com.ss.utopia.auth.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ss.utopia.auth.config.Constants;
+import com.ss.utopia.auth.dto.CreateUserAccountDto;
+import com.ss.utopia.auth.exception.DuplicateEmailException;
+import com.ss.utopia.auth.repository.UserAccountRepository;
+import com.ss.utopia.auth.service.UserAccountService;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@WebMvcTest
+class UserAccountControllerTest {
+
+  ObjectMapper jsonMapper = new ObjectMapper();
+
+  @Autowired
+  WebApplicationContext wac;
+
+  @MockBean
+  UserAccountRepository repository;
+  @MockBean
+  UserAccountService service;
+
+  private MockMvc mvc;
+
+  @BeforeEach
+  void beforeEach() {
+    mvc = MockMvcBuilders
+        .webAppContextSetup(wac)
+        .apply(springSecurity())
+        .build();
+  }
+
+  @Test
+  void test_createAccount_StatusIsCreatedAndHeaderContainsLocation() throws Exception {
+    var createDto = CreateUserAccountDto.builder()
+        .email("test1@test.com")
+        .password("abCD1234!@")
+        .build();
+    var jsonDto = jsonMapper.writeValueAsString(createDto);
+
+    var headerName = "Location";
+    var headerVal = Constants.API_V_0_1_ACCOUNTS;
+
+    mvc.perform(
+        post(Constants.API_V_0_1_ACCOUNTS)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(jsonDto))
+        .andExpect(status().isCreated())
+        .andExpect(header().string(headerName, Matchers.containsString(headerVal)));
+  }
+
+  @Test
+  void test_createAccount_OnDuplicateEmailStatusIsConflict() throws Exception {
+    var createDto = CreateUserAccountDto.builder()
+        .email("test2@test.com")
+        .password("abCD1234!@")
+        .build();
+
+    when(service.createNewAccount(createDto))
+        .thenThrow(new DuplicateEmailException("test2@test.com"));
+
+    var jsonDto = jsonMapper.writeValueAsString(createDto);
+
+    mvc.perform(
+        post(Constants.API_V_0_1_ACCOUNTS)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(jsonDto))
+        .andExpect(status().isConflict());
+  }
+}

--- a/src/test/java/com/ss/utopia/auth/controller/UserAccountControllerTest.java
+++ b/src/test/java/com/ss/utopia/auth/controller/UserAccountControllerTest.java
@@ -13,6 +13,7 @@ import com.ss.utopia.auth.entity.UserAccount;
 import com.ss.utopia.auth.exception.DuplicateEmailException;
 import com.ss.utopia.auth.repository.UserAccountRepository;
 import com.ss.utopia.auth.service.UserAccountService;
+import java.util.UUID;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,12 +56,13 @@ class UserAccountControllerTest {
         .build();
     var jsonDto = jsonMapper.writeValueAsString(createDto);
 
+    var uuid = UUID.randomUUID();
 
     var headerName = "Location";
-    var expectedHeaderVal = Constants.API_V_0_1_ACCOUNTS + "/1";
+    var expectedHeaderVal = Constants.API_V_0_1_ACCOUNTS + "/" + uuid;
 
     when(service.createNewAccount(createDto))
-        .thenReturn(UserAccount.builder().id(1L).build());
+        .thenReturn(UserAccount.builder().id(uuid).build());
 
     mvc.perform(
         post(Constants.API_V_0_1_ACCOUNTS)

--- a/src/test/java/com/ss/utopia/auth/controller/UserAccountControllerTest.java
+++ b/src/test/java/com/ss/utopia/auth/controller/UserAccountControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ss.utopia.auth.config.Constants;
 import com.ss.utopia.auth.dto.CreateUserAccountDto;
+import com.ss.utopia.auth.entity.UserAccount;
 import com.ss.utopia.auth.exception.DuplicateEmailException;
 import com.ss.utopia.auth.repository.UserAccountRepository;
 import com.ss.utopia.auth.service.UserAccountService;
@@ -54,15 +55,19 @@ class UserAccountControllerTest {
         .build();
     var jsonDto = jsonMapper.writeValueAsString(createDto);
 
+
     var headerName = "Location";
-    var headerVal = Constants.API_V_0_1_ACCOUNTS;
+    var expectedHeaderVal = Constants.API_V_0_1_ACCOUNTS + "/1";
+
+    when(service.createNewAccount(createDto))
+        .thenReturn(UserAccount.builder().id(1L).build());
 
     mvc.perform(
         post(Constants.API_V_0_1_ACCOUNTS)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .content(jsonDto))
         .andExpect(status().isCreated())
-        .andExpect(header().string(headerName, Matchers.containsString(headerVal)));
+        .andExpect(header().string(headerName, expectedHeaderVal));
   }
 
   @Test

--- a/src/test/java/com/ss/utopia/auth/service/UserAccountServiceImplTest.java
+++ b/src/test/java/com/ss/utopia/auth/service/UserAccountServiceImplTest.java
@@ -1,0 +1,131 @@
+package com.ss.utopia.auth.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.ss.utopia.auth.dto.CreateUserAccountDto;
+import com.ss.utopia.auth.entity.UserAccount;
+import com.ss.utopia.auth.entity.UserRole;
+import com.ss.utopia.auth.exception.DuplicateEmailException;
+import com.ss.utopia.auth.repository.UserAccountRepository;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+class UserAccountServiceImplTest {
+
+
+  UserAccountRepository repository = Mockito.mock(UserAccountRepository.class);
+  BCryptPasswordEncoder passwordEncoder = Mockito.mock(BCryptPasswordEncoder.class);
+  UserAccountService service = new UserAccountServiceImpl(repository, passwordEncoder);
+
+  @BeforeEach
+  void beforeEach() {
+    Mockito.reset(repository);
+
+  }
+
+  @Test
+  void test_createNewAccount_ReturnsCreatedAccountOnSuccess() {
+    var now = ZonedDateTime.now();
+
+    var expectedId = 1L;
+    var email = "test@test.com";
+    var unhashedPassword = "abCD1234!@";
+    var hashedPassword = "ImFiQ0QxMjM0IUAi";
+
+    when(passwordEncoder.encode(unhashedPassword))
+        .thenReturn(hashedPassword);
+
+    var accountWithId = UserAccount.builder()
+        .id(expectedId)
+        .email(email)
+        .hashedPassword(hashedPassword)
+        .creationDateTime(now)
+        .userRole(UserRole.DEFAULT)
+        .build();
+
+    var accountWithoutId = UserAccount.builder()
+        .email(email)
+        .hashedPassword(hashedPassword)
+        .creationDateTime(now)
+        .userRole(UserRole.DEFAULT)
+        .build();
+
+    when(repository.save(accountWithoutId)).thenReturn(accountWithId);
+
+    var dto = CreateUserAccountDto.builder()
+        .email(email)
+        .password(unhashedPassword)
+        .build();
+
+    var result = service.createNewAccount(dto);
+
+    assertEquals(accountWithId, result);
+  }
+
+  @Test
+  void test_createNewAccount_ThrowsDuplicateEmailExceptionOnDuplicateEmailAccount() {
+    var email = "test@test.com";
+    when(repository.findByEmail(anyString()))
+        .thenReturn(Optional.of(UserAccount.builder().build()));
+
+    var dto = CreateUserAccountDto.builder()
+        .email(email)
+        .password("abCD1234!@")
+        .build();
+
+    assertThrows(DuplicateEmailException.class, () -> service.createNewAccount(dto));
+
+    try {
+      service.createNewAccount(dto);
+    } catch (DuplicateEmailException ex) {
+      var emailInEx = ex.getEmail();
+      assertEquals(email, emailInEx);
+    }
+  }
+
+  @Test
+  void test_createNewAccount_ThrowsIllegalArgumentExceptionOnInvalidDTO() {
+    when(repository.findByEmail(anyString()))
+        .thenReturn(Optional.empty());
+
+    var validEmail = "test@test.com";
+    var validPassword = "abCD1234!@";
+
+    var dto = new CreateUserAccountDto();
+
+    dto.setEmail(validEmail);
+    dto.setPassword(validPassword);
+
+    // sanity
+    assertDoesNotThrow(() -> service.createNewAccount(dto));
+
+    dto.setEmail(null);
+    assertThrows(IllegalArgumentException.class, () -> service.createNewAccount(dto));
+
+    dto.setEmail("");
+    assertThrows(IllegalArgumentException.class, () -> service.createNewAccount(dto));
+
+    dto.setEmail("Definitely not an email");
+    assertThrows(IllegalArgumentException.class, () -> service.createNewAccount(dto));
+
+    dto.setEmail(validEmail);
+    dto.setPassword(null);
+    assertThrows(IllegalArgumentException.class, () -> service.createNewAccount(dto));
+
+    dto.setPassword("");
+    assertThrows(IllegalArgumentException.class, () -> service.createNewAccount(dto));
+
+    dto.setPassword("asdfasdfasdf");
+    assertThrows(IllegalArgumentException.class, () -> service.createNewAccount(dto));
+
+    assertThrows(IllegalArgumentException.class, () -> service.createNewAccount(null));
+  }
+}

--- a/src/test/java/com/ss/utopia/auth/service/UserAccountServiceImplTest.java
+++ b/src/test/java/com/ss/utopia/auth/service/UserAccountServiceImplTest.java
@@ -13,6 +13,7 @@ import com.ss.utopia.auth.exception.DuplicateEmailException;
 import com.ss.utopia.auth.repository.UserAccountRepository;
 import java.time.ZonedDateTime;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -36,7 +37,7 @@ class UserAccountServiceImplTest {
   void test_createNewAccount_ReturnsCreatedAccountOnSuccess() {
     var now = ZonedDateTime.now();
 
-    var expectedId = 1L;
+    var expectedId = UUID.randomUUID();
     var email = "test@test.com";
     var unhashedPassword = "abCD1234!@";
     var hashedPassword = "ImFiQ0QxMjM0IUAi";

--- a/src/test/java/com/ss/utopia/auth/service/UserAccountServiceImplTest.java
+++ b/src/test/java/com/ss/utopia/auth/service/UserAccountServiceImplTest.java
@@ -23,7 +23,8 @@ class UserAccountServiceImplTest {
 
   UserAccountRepository repository = Mockito.mock(UserAccountRepository.class);
   BCryptPasswordEncoder passwordEncoder = Mockito.mock(BCryptPasswordEncoder.class);
-  UserAccountService service = new UserAccountServiceImpl(repository, passwordEncoder);
+  UserAccountService serviceThatIsBeingTested = new UserAccountServiceImpl(repository,
+                                                                           passwordEncoder);
 
   @BeforeEach
   void beforeEach() {
@@ -65,7 +66,7 @@ class UserAccountServiceImplTest {
         .password(unhashedPassword)
         .build();
 
-    var result = service.createNewAccount(dto);
+    var result = serviceThatIsBeingTested.createNewAccount(dto);
 
     assertEquals(accountWithId, result);
   }
@@ -81,10 +82,11 @@ class UserAccountServiceImplTest {
         .password("abCD1234!@")
         .build();
 
-    assertThrows(DuplicateEmailException.class, () -> service.createNewAccount(dto));
+    assertThrows(DuplicateEmailException.class,
+                 () -> serviceThatIsBeingTested.createNewAccount(dto));
 
     try {
-      service.createNewAccount(dto);
+      serviceThatIsBeingTested.createNewAccount(dto);
     } catch (DuplicateEmailException ex) {
       var emailInEx = ex.getEmail();
       assertEquals(email, emailInEx);
@@ -105,27 +107,34 @@ class UserAccountServiceImplTest {
     dto.setPassword(validPassword);
 
     // sanity
-    assertDoesNotThrow(() -> service.createNewAccount(dto));
+    assertDoesNotThrow(() -> serviceThatIsBeingTested.createNewAccount(dto));
 
     dto.setEmail(null);
-    assertThrows(IllegalArgumentException.class, () -> service.createNewAccount(dto));
+    assertThrows(IllegalArgumentException.class,
+                 () -> serviceThatIsBeingTested.createNewAccount(dto));
 
     dto.setEmail("");
-    assertThrows(IllegalArgumentException.class, () -> service.createNewAccount(dto));
+    assertThrows(IllegalArgumentException.class,
+                 () -> serviceThatIsBeingTested.createNewAccount(dto));
 
     dto.setEmail("Definitely not an email");
-    assertThrows(IllegalArgumentException.class, () -> service.createNewAccount(dto));
+    assertThrows(IllegalArgumentException.class,
+                 () -> serviceThatIsBeingTested.createNewAccount(dto));
 
     dto.setEmail(validEmail);
     dto.setPassword(null);
-    assertThrows(IllegalArgumentException.class, () -> service.createNewAccount(dto));
+    assertThrows(IllegalArgumentException.class,
+                 () -> serviceThatIsBeingTested.createNewAccount(dto));
 
     dto.setPassword("");
-    assertThrows(IllegalArgumentException.class, () -> service.createNewAccount(dto));
+    assertThrows(IllegalArgumentException.class,
+                 () -> serviceThatIsBeingTested.createNewAccount(dto));
 
     dto.setPassword("asdfasdfasdf");
-    assertThrows(IllegalArgumentException.class, () -> service.createNewAccount(dto));
+    assertThrows(IllegalArgumentException.class,
+                 () -> serviceThatIsBeingTested.createNewAccount(dto));
 
-    assertThrows(IllegalArgumentException.class, () -> service.createNewAccount(null));
+    assertThrows(IllegalArgumentException.class,
+                 () -> serviceThatIsBeingTested.createNewAccount(null));
   }
 }


### PR DESCRIPTION
Basic implementation of user account creation.
A REST endpoint has been set up to receive a DTO containing user email and password to be persisted in the database.
BCrypt has been used to encrypt a hashed and salted copy of the password.
Currently, the application is pointed to a local docker instance of MySQL for persistence and will need to be modified in the future.