### PR TITLE
Implement customer account deletion

### DIFF
--- a/src/main/java/com/ss/utopia/auth/client/EmailClient.java
+++ b/src/main/java/com/ss/utopia/auth/client/EmailClient.java
@@ -10,4 +10,6 @@ public interface EmailClient {
   void sendForgetPasswordEmail(String token, String email);
 
   void sendConfirmAccountEmail(String recipient, UUID confirmationToken);
+
+  void sendDeleteAccountEmail(String recipient, UUID token);
 }

--- a/src/main/java/com/ss/utopia/auth/client/RestTemplateEmailClient.java
+++ b/src/main/java/com/ss/utopia/auth/client/RestTemplateEmailClient.java
@@ -2,6 +2,7 @@ package com.ss.utopia.auth.client;
 
 import com.ss.utopia.auth.client.email.AbstractUrlEmail;
 import com.ss.utopia.auth.client.email.AccountConfirmationEmail;
+import com.ss.utopia.auth.client.email.DeleteAccountEmail;
 import com.ss.utopia.auth.client.email.PasswordResetEmail;
 import com.ss.utopia.auth.exception.EmailNotSentException;
 import java.util.UUID;
@@ -28,6 +29,8 @@ public class RestTemplateEmailClient implements EmailClient {
   private String passwordResetBaseUrl;
   @Setter
   private String confirmationBaseUrl;
+  @Setter
+  private String deletionBaseUrl;
 
   private RestTemplateBuilder builder;
   private RestTemplate restTemplate;
@@ -57,6 +60,15 @@ public class RestTemplateEmailClient implements EmailClient {
     var confirmationUrl = confirmationBaseUrl + "/" + confirmationToken;
 
     var email = new AccountConfirmationEmail(recipientEmail, confirmationUrl);
+    var response = restTemplate.postForEntity(sesEndpoint, email, String.class);
+
+    handleResponse(response, email);
+  }
+
+  @Override
+  public void sendDeleteAccountEmail(String recipient, UUID token) {
+    var deletionUrl = deletionBaseUrl + "/" + token;
+    var email = new DeleteAccountEmail(recipient, deletionUrl);
     var response = restTemplate.postForEntity(sesEndpoint, email, String.class);
 
     handleResponse(response, email);

--- a/src/main/java/com/ss/utopia/auth/client/email/DeleteAccountEmail.java
+++ b/src/main/java/com/ss/utopia/auth/client/email/DeleteAccountEmail.java
@@ -1,0 +1,16 @@
+package com.ss.utopia.auth.client.email;
+
+public class DeleteAccountEmail extends AbstractUrlEmail {
+
+  public static final String DEFAULT_SUBJECT = "Confirm Your Account Deletion";
+  public static final String DEFAULT_MESSAGE = "Please click the following link to confirm your account deletion."
+      + "<br>If you've changed your mind, you can safely ignore this email.";
+
+  public DeleteAccountEmail(String recipient, String url) {
+    this(recipient, DEFAULT_SUBJECT, DEFAULT_MESSAGE, url);
+  }
+
+  public DeleteAccountEmail(String recipient, String subject, String message, String url) {
+    super(recipient, subject, message, url);
+  }
+}

--- a/src/main/java/com/ss/utopia/auth/dto/DeleteAccountDto.java
+++ b/src/main/java/com/ss/utopia/auth/dto/DeleteAccountDto.java
@@ -1,0 +1,32 @@
+package com.ss.utopia.auth.dto;
+
+import java.util.UUID;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class DeleteAccountDto {
+
+  @NotNull
+  private UUID id;
+
+  @Email
+  @NotNull
+  private String email;
+
+  @NotNull
+  @NotBlank
+  @ToString.Exclude
+  @EqualsAndHashCode.Exclude
+  private String password;
+}

--- a/src/main/java/com/ss/utopia/auth/entity/AccountAction.java
+++ b/src/main/java/com/ss/utopia/auth/entity/AccountAction.java
@@ -3,9 +3,10 @@ package com.ss.utopia.auth.entity;
 //todo get ttl from config
 public enum AccountAction {
   PASSWORD_RESET(10), // 10 minutes
-  CONFIRMATION(60); // 1 hour
+  CONFIRMATION(60), // 1 hour
+  DELETION(10); // 10 minutes
 
-  private int minutesToLive;
+  private final int minutesToLive;
 
   AccountAction(int minutesToLive) {
     this.minutesToLive = minutesToLive;

--- a/src/main/java/com/ss/utopia/auth/entity/UserRole.java
+++ b/src/main/java/com/ss/utopia/auth/entity/UserRole.java
@@ -5,7 +5,8 @@ public enum UserRole {
   CUSTOMER("ROLE_CUSTOMER"),
   TRAVEL_AGENT("ROLE_TRAVEL_AGENT"),
   EMPLOYEE("ROLE_EMPLOYEE"),
-  ADMIN("ROLE_ADMIN");
+  ADMIN("ROLE_ADMIN"),
+  SERVICE("ROLE_SERVICE");
 
   private final String roleName;
 

--- a/src/main/java/com/ss/utopia/auth/exception/ExceptionControllerAdvisor.java
+++ b/src/main/java/com/ss/utopia/auth/exception/ExceptionControllerAdvisor.java
@@ -81,6 +81,19 @@ public class ExceptionControllerAdvisor {
     return response;
   }
 
+  @ResponseStatus(HttpStatus.CONFLICT)
+  @ExceptionHandler(IllegalCustomerAccountDeletionException.class)
+  public Map<String, Object> illegalCustomerAccountDeletionException(
+      IllegalCustomerAccountDeletionException ex) {
+    log.error(ex.getMessage());
+
+    var response = new HashMap<String, Object>();
+    response.put("error", ex.getMessage());
+    response.put("role", ex.getUserAccount().getUserRole().getRoleName());
+    response.put("status", HttpStatus.CONFLICT.value());
+    return response;
+  }
+
   private String getErrorMessageOrDefault(FieldError error) {
     var msg = error.getDefaultMessage();
     msg = msg == null || msg.isBlank() ? "Unknown validation failure." : msg;

--- a/src/main/java/com/ss/utopia/auth/exception/IllegalCustomerAccountDeletionException.java
+++ b/src/main/java/com/ss/utopia/auth/exception/IllegalCustomerAccountDeletionException.java
@@ -1,0 +1,16 @@
+package com.ss.utopia.auth.exception;
+
+import com.ss.utopia.auth.entity.UserAccount;
+import lombok.Getter;
+
+public class IllegalCustomerAccountDeletionException extends IllegalArgumentException {
+
+  @Getter
+  private final UserAccount userAccount;
+
+  public IllegalCustomerAccountDeletionException(UserAccount userAccount) {
+    super("Unable to initiate deletion, account does not belong to a customer. AccountId="
+              + userAccount.getId());
+    this.userAccount = userAccount;
+  }
+}

--- a/src/main/java/com/ss/utopia/auth/exception/InvalidTokenException.java
+++ b/src/main/java/com/ss/utopia/auth/exception/InvalidTokenException.java
@@ -1,7 +1,13 @@
 package com.ss.utopia.auth.exception;
 
+import com.ss.utopia.auth.entity.AccountActionToken;
+
 public class InvalidTokenException extends IllegalStateException {
   public InvalidTokenException(String token) {
     super("Invalid password reset token="+token);
+  }
+
+  public InvalidTokenException(AccountActionToken token) {
+    super("Invalid action token id="+token.getToken());
   }
 }

--- a/src/main/java/com/ss/utopia/auth/security/SecurityConfig.java
+++ b/src/main/java/com/ss/utopia/auth/security/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -19,6 +20,7 @@ import org.springframework.web.cors.CorsUtils;
 @Slf4j
 @Configuration
 @EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 

--- a/src/main/java/com/ss/utopia/auth/security/permissions/AdminOnlyPermission.java
+++ b/src/main/java/com/ss/utopia/auth/security/permissions/AdminOnlyPermission.java
@@ -1,0 +1,11 @@
+package com.ss.utopia.auth.security.permissions;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("hasRole('ADMIN')")
+public @interface AdminOnlyPermission {
+
+}

--- a/src/main/java/com/ss/utopia/auth/security/permissions/ServiceOnlyPermission.java
+++ b/src/main/java/com/ss/utopia/auth/security/permissions/ServiceOnlyPermission.java
@@ -1,0 +1,11 @@
+package com.ss.utopia.auth.security.permissions;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("hasAnyRole('ADMIN', 'SERVICE')")
+public @interface ServiceOnlyPermission {
+
+}

--- a/src/main/java/com/ss/utopia/auth/service/AccountActionTokenService.java
+++ b/src/main/java/com/ss/utopia/auth/service/AccountActionTokenService.java
@@ -1,0 +1,25 @@
+package com.ss.utopia.auth.service;
+
+import com.ss.utopia.auth.entity.AccountAction;
+import com.ss.utopia.auth.entity.AccountActionToken;
+import com.ss.utopia.auth.exception.InvalidTokenException;
+import java.util.UUID;
+
+public interface AccountActionTokenService {
+
+  AccountActionToken getToken(UUID token);
+
+  default AccountActionToken getAndValidateToken(UUID token) {
+    var retrieved = getToken(token);
+    validateToken(retrieved);
+    return retrieved;
+  }
+
+  void validateToken(AccountActionToken token) throws InvalidTokenException;
+
+  AccountActionToken createToken(UUID ownerId, AccountAction action);
+
+  void deleteToken(AccountActionToken token);
+
+  void deleteToken(UUID tokenId);
+}

--- a/src/main/java/com/ss/utopia/auth/service/AccountActionTokenServiceImpl.java
+++ b/src/main/java/com/ss/utopia/auth/service/AccountActionTokenServiceImpl.java
@@ -1,0 +1,54 @@
+package com.ss.utopia.auth.service;
+
+import com.ss.utopia.auth.entity.AccountAction;
+import com.ss.utopia.auth.entity.AccountActionToken;
+import com.ss.utopia.auth.exception.InvalidTokenException;
+import com.ss.utopia.auth.exception.NoSuchAccountActionToken;
+import com.ss.utopia.auth.repository.AccountActionTokenRepository;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AccountActionTokenServiceImpl implements AccountActionTokenService {
+
+  private final AccountActionTokenRepository accountActionTokenRepository;
+
+  @Override
+  public AccountActionToken getToken(UUID token) {
+    return accountActionTokenRepository.findById(token)
+        .orElseThrow(() -> new NoSuchAccountActionToken(token));
+  }
+
+  @Override
+  public void validateToken(AccountActionToken token) throws InvalidTokenException {
+    var now = ZonedDateTime.now();
+    var creation = token.getCreation();
+    var expiration = creation.plusMinutes(token.getAction().getMinutesToLive());
+
+    if (!token.isActive() || now.isAfter(expiration)) {
+      throw new InvalidTokenException(token);
+    }
+  }
+
+  @Override
+  public AccountActionToken createToken(UUID ownerId, AccountAction action) {
+    return accountActionTokenRepository.save(AccountActionToken.builder()
+                                                 .ownerAccountId(ownerId)
+                                                 .action(action)
+                                                 .build());
+  }
+
+  @Override
+  public void deleteToken(AccountActionToken token) {
+    deleteToken(token.getToken());
+  }
+
+  @Override
+  public void deleteToken(UUID tokenId) {
+    accountActionTokenRepository.findById(tokenId)
+        .ifPresent(accountActionTokenRepository::delete);
+  }
+}

--- a/src/main/java/com/ss/utopia/auth/service/UserAccountService.java
+++ b/src/main/java/com/ss/utopia/auth/service/UserAccountService.java
@@ -1,11 +1,14 @@
 package com.ss.utopia.auth.service;
 
 import com.ss.utopia.auth.dto.CreateUserAccountDto;
-import com.ss.utopia.auth.dto.ResetPasswordDto;
+import com.ss.utopia.auth.dto.DeleteAccountDto;
 import com.ss.utopia.auth.entity.UserAccount;
+import java.util.List;
 import java.util.UUID;
 
 public interface UserAccountService {
+
+  List<UserAccount> getAll();
 
   UserAccount getById(UUID id);
 
@@ -18,4 +21,12 @@ public interface UserAccountService {
   void sendAccountConfirmation(UserAccount userAccount);
 
   void confirmAccountRegistration(UUID confirmationTokenId);
+
+  void deleteAccountById(UUID accountId);
+
+  UUID deleteAccountByEmail(String accountEmail);
+
+  void initiateCustomerDeletion(DeleteAccountDto deleteAccountDto);
+
+  UUID completeCustomerDeletion(DeleteAccountDto deleteAccountDto);
 }

--- a/src/main/java/com/ss/utopia/auth/service/UserAccountServiceImpl.java
+++ b/src/main/java/com/ss/utopia/auth/service/UserAccountServiceImpl.java
@@ -2,21 +2,26 @@ package com.ss.utopia.auth.service;
 
 import com.ss.utopia.auth.client.EmailClient;
 import com.ss.utopia.auth.dto.CreateUserAccountDto;
+import com.ss.utopia.auth.dto.DeleteAccountDto;
 import com.ss.utopia.auth.entity.AccountAction;
-import com.ss.utopia.auth.entity.AccountActionToken;
 import com.ss.utopia.auth.entity.UserAccount;
 import com.ss.utopia.auth.entity.UserRole;
 import com.ss.utopia.auth.exception.DuplicateEmailException;
 import com.ss.utopia.auth.exception.EmailNotSentException;
-import com.ss.utopia.auth.exception.NoSuchAccountActionToken;
+import com.ss.utopia.auth.exception.IllegalCustomerAccountDeletionException;
 import com.ss.utopia.auth.exception.NoSuchUserAccountException;
-import com.ss.utopia.auth.repository.AccountActionTokenRepository;
 import com.ss.utopia.auth.repository.UserAccountRepository;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,10 +32,19 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserAccountServiceImpl implements UserAccountService {
 
   private final UserAccountRepository userAccountRepository;
+  private final AuthenticationManager authenticationManager;
   private final BCryptPasswordEncoder passwordEncoder;
-  private final AccountActionTokenRepository accountActionTokenRepository;
+  private final AccountActionTokenService accountActionTokenService;
   private final EmailClient emailClient;
   private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+  @Override
+  public List<UserAccount> getAll() {
+    return userAccountRepository.findAll()
+        .stream()
+        .peek(account -> account.setPassword(null))
+        .collect(Collectors.toList());
+  }
 
   @Override
   public UserAccount getById(UUID id) {
@@ -68,36 +82,86 @@ public class UserAccountServiceImpl implements UserAccountService {
 
   @Override
   public void sendAccountConfirmation(UserAccount userAccount) {
-    var confirmationToken = AccountActionToken.builder()
-        .ownerAccountId(userAccount.getId())
-        .action(AccountAction.CONFIRMATION)
-        .build();
-
-    confirmationToken = accountActionTokenRepository.save(confirmationToken);
+    var confirmationToken = accountActionTokenService.createToken(userAccount.getId(),
+                                                                  AccountAction.CONFIRMATION);
 
     emailClient.sendConfirmAccountEmail(userAccount.getEmail(), confirmationToken.getToken());
   }
 
   @Override
   public void confirmAccountRegistration(UUID confirmationTokenId) {
-    accountActionTokenRepository.findById(confirmationTokenId)
-        .ifPresentOrElse(token -> {
-          var account = getById(token.getOwnerAccountId());
-          account.setConfirmed(true);
-          // don't modify non-customer accounts with confirmation
-          if (account.getUserRole().equals(UserRole.DEFAULT)) {
-            account.setUserRole(UserRole.CUSTOMER);
-          }
-          userAccountRepository.save(account);
-        }, () -> {
-          throw new NoSuchAccountActionToken(confirmationTokenId);
-        });
+    var token = accountActionTokenService.getAndValidateToken(confirmationTokenId);
+
+    var account = getById(token.getOwnerAccountId());
+    account.setConfirmed(true);
+
+    // don't modify non-customer accounts with confirmation
+    if (isCustomerOrDefault(account)) {
+      account.setUserRole(UserRole.CUSTOMER);
+    }
+    userAccountRepository.save(account);
   }
 
   @Override
   public void updateAccount(UserAccount userAccount) {
     userAccountRepository.findById(userAccount.getId())
         .ifPresent(a -> userAccountRepository.save(userAccount));
+  }
+
+  @Override
+  public void deleteAccountById(UUID accountId) {
+    var account = getById(accountId);
+    userAccountRepository.delete(account);
+  }
+
+  @Override
+  public UUID deleteAccountByEmail(String accountEmail) {
+    var account = getByEmail(accountEmail);
+    userAccountRepository.delete(account);
+    return account.getId();
+  }
+
+  @Override
+  public void initiateCustomerDeletion(DeleteAccountDto deleteAccountDto) {
+    authenticate(deleteAccountDto);
+
+    var account = getById(deleteAccountDto.getId());
+
+    if (!isCustomerOrDefault(account)) {
+      throw new IllegalCustomerAccountDeletionException(account);
+    }
+
+    var actionToken = accountActionTokenService.createToken(account.getId(),
+                                                            AccountAction.DELETION);
+    emailClient.sendDeleteAccountEmail(account.getEmail(), actionToken.getToken());
+  }
+
+  @Override
+  public UUID completeCustomerDeletion(DeleteAccountDto deleteAccountDto) {
+    authenticate(deleteAccountDto);
+
+    var actionToken = accountActionTokenService.getAndValidateToken(deleteAccountDto.getId());
+    var account = getByEmail(deleteAccountDto.getEmail());
+
+    if (!isCustomerOrDefault(account)) {
+      throw new IllegalCustomerAccountDeletionException(account);
+    }
+
+    deleteAccountByEmail(deleteAccountDto.getEmail());
+    accountActionTokenService.deleteToken(actionToken);
+    return account.getId();
+  }
+
+  private void authenticate(DeleteAccountDto deleteAccountDto) {
+    var authToken = new UsernamePasswordAuthenticationToken(deleteAccountDto.getEmail(),
+                                                            deleteAccountDto.getPassword(),
+                                                            Collections.emptySet());
+    authenticationManager.authenticate(authToken);
+  }
+
+  private boolean isCustomerOrDefault(UserAccount userAccount) {
+    return userAccount.getUserRole().equals(UserRole.CUSTOMER)
+        || userAccount.getUserRole().equals(UserRole.DEFAULT);
   }
 
   private void validateDto(CreateUserAccountDto dto) {

--- a/src/test/java/com/ss/utopia/auth/controller/UserAccountControllerSecurityTests.java
+++ b/src/test/java/com/ss/utopia/auth/controller/UserAccountControllerSecurityTests.java
@@ -1,0 +1,429 @@
+package com.ss.utopia.auth.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ss.utopia.auth.dto.DeleteAccountDto;
+import com.ss.utopia.auth.security.SecurityConstants;
+import com.ss.utopia.auth.service.PasswordResetService;
+import com.ss.utopia.auth.service.UserAccountService;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+public class UserAccountControllerSecurityTests {
+
+  final Date expiresAt = Date.from(LocalDateTime.now().plusDays(1).toInstant(ZoneOffset.UTC));
+  @Autowired
+  WebApplicationContext wac;
+  @MockBean
+  SecurityConstants securityConstants;
+
+  @MockBean
+  UserAccountService userAccountService;
+  @MockBean
+  PasswordResetService passwordResetService;
+
+  MockMvc mvc;
+
+  @BeforeEach
+  void beforeEach() {
+    mvc = MockMvcBuilders
+        .webAppContextSetup(wac)
+        .apply(springSecurity())
+        .build();
+
+    when(securityConstants.getEndpoint()).thenReturn("/authenticate");
+    when(securityConstants.getJwtIssuer()).thenReturn("test-issuer");
+    when(securityConstants.getExpiresAt()).thenReturn(expiresAt);
+    when(securityConstants.getJwtSecret()).thenReturn("superSecret");
+    when(securityConstants.getUserIdClaimKey()).thenReturn("userId");
+    when(securityConstants.getAuthorityClaimKey()).thenReturn("Authorities");
+    when(securityConstants.getJwtHeaderName()).thenReturn("Authorization");
+    when(securityConstants.getJwtHeaderPrefix()).thenReturn("Bearer ");
+  }
+
+  String getJwt(MockUser mockUser) {
+    var jwt = JWT.create()
+        .withSubject(mockUser.email)
+        .withIssuer(securityConstants.getJwtIssuer())
+        .withClaim(securityConstants.getUserIdClaimKey(), mockUser.id)
+        .withClaim(securityConstants.getAuthorityClaimKey(), List.of(mockUser.getAuthority()))
+        .withExpiresAt(expiresAt)
+        .sign(Algorithm.HMAC512(securityConstants.getJwtSecret()));
+    return "Bearer " + jwt;
+  }
+
+  @Test
+  void test_getAllAccounts_OnlyAllowedByAdmin() throws Exception {
+    var alwaysAuthed = List.of(MockUser.ADMIN);
+    for (var user : alwaysAuthed) {
+      var result = mvc
+          .perform(
+              get(EndpointConstants.API_V_0_1_ACCOUNTS)
+                  .header("Authorization", getJwt(user)))
+          .andReturn();
+      assertNotEquals(403, result.getResponse().getStatus());
+      assertNotEquals(401, result.getResponse().getStatus());
+    }
+
+    var notauthed = List.of(MockUser.SERVICE,
+                            MockUser.EMPLOYEE,
+                            MockUser.TRAVEL_AGENT,
+                            MockUser.MATCH_CUSTOMER,
+                            MockUser.DEFAULT,
+                            MockUser.UNMATCH_CUSTOMER);
+    for (var user : notauthed) {
+      var result = mvc
+          .perform(
+              get(EndpointConstants.API_V_0_1_ACCOUNTS)
+                  .header("Authorization", getJwt(user)))
+          .andReturn();
+      assertEquals(403, result.getResponse().getStatus(), "Failure on: " + user);
+    }
+
+    var result = mvc
+        .perform(
+            get(EndpointConstants.API_V_0_1_ACCOUNTS))
+        .andReturn();
+    assertEquals(403, result.getResponse().getStatus());
+  }
+
+  @Test
+  void test_createNewAccount_AllowedByAny() throws Exception {
+    var alwaysAuthed = List.of(MockUser.ADMIN,
+                               MockUser.SERVICE,
+                               MockUser.EMPLOYEE,
+                               MockUser.TRAVEL_AGENT,
+                               MockUser.MATCH_CUSTOMER,
+                               MockUser.DEFAULT,
+                               MockUser.UNMATCH_CUSTOMER);
+    for (var user : alwaysAuthed) {
+      var result = mvc
+          .perform(
+              post(EndpointConstants.API_V_0_1_ACCOUNTS)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("")
+                  .header("Authorization", getJwt(user)))
+          .andReturn().getResponse().getStatus();
+
+      assertNotEquals(403, result, "Failed on " + user);
+      assertNotEquals(401, result, "Failed on " + user);
+    }
+
+    var result = mvc
+        .perform(
+            post(EndpointConstants.API_V_0_1_ACCOUNTS)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(""))
+        .andReturn().getResponse().getStatus();
+
+    assertNotEquals(403, result, "Failed on no authorization");
+    assertNotEquals(401, result, "Failed on no authorization");
+  }
+
+  @Test
+  void test_confirmAccountRegistration_AllowedByAny() throws Exception {
+    var alwaysAuthed = List.of(MockUser.ADMIN,
+                               MockUser.SERVICE,
+                               MockUser.EMPLOYEE,
+                               MockUser.TRAVEL_AGENT,
+                               MockUser.MATCH_CUSTOMER,
+                               MockUser.DEFAULT,
+                               MockUser.UNMATCH_CUSTOMER);
+    for (var user : alwaysAuthed) {
+      var result = mvc
+          .perform(
+              put(EndpointConstants.API_V_0_1_ACCOUNTS + "/confirm/" + UUID.randomUUID())
+                  .header("Authorization", getJwt(user)))
+          .andReturn().getResponse().getStatus();
+
+      assertNotEquals(403, result, "Failed on " + user);
+      assertNotEquals(401, result, "Failed on " + user);
+    }
+
+    var result = mvc
+        .perform(
+            put(EndpointConstants.API_V_0_1_ACCOUNTS + "/confirm/" + UUID.randomUUID()))
+        .andReturn().getResponse().getStatus();
+
+    assertNotEquals(403, result, "Failed on no authorization");
+    assertNotEquals(401, result, "Failed on no authorization");
+  }
+
+  @Test
+  void test_addPasswordReset_AllowedByAny() throws Exception {
+    var alwaysAuthed = List.of(MockUser.ADMIN,
+                               MockUser.SERVICE,
+                               MockUser.EMPLOYEE,
+                               MockUser.TRAVEL_AGENT,
+                               MockUser.MATCH_CUSTOMER,
+                               MockUser.DEFAULT,
+                               MockUser.UNMATCH_CUSTOMER);
+    for (var user : alwaysAuthed) {
+      var result = mvc
+          .perform(
+              post(EndpointConstants.API_V_0_1_ACCOUNTS + "/password-reset")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("")
+                  .header("Authorization", getJwt(user)))
+          .andReturn().getResponse().getStatus();
+
+      assertNotEquals(403, result, "Failed on " + user);
+      assertNotEquals(401, result, "Failed on " + user);
+    }
+
+    var result = mvc
+        .perform(
+            post(EndpointConstants.API_V_0_1_ACCOUNTS + "/password-reset")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(""))
+        .andReturn().getResponse().getStatus();
+
+    assertNotEquals(403, result, "Failed on no authorization");
+    assertNotEquals(401, result, "Failed on no authorization");
+  }
+
+  @Test
+  void test_tokenCheck_AllowedByAny() throws Exception {
+    var alwaysAuthed = List.of(MockUser.ADMIN,
+                               MockUser.SERVICE,
+                               MockUser.EMPLOYEE,
+                               MockUser.TRAVEL_AGENT,
+                               MockUser.MATCH_CUSTOMER,
+                               MockUser.DEFAULT,
+                               MockUser.UNMATCH_CUSTOMER);
+    for (var user : alwaysAuthed) {
+      var result = mvc
+          .perform(
+              get(EndpointConstants.API_V_0_1_ACCOUNTS + "/new-password/potato")
+                  .header("Authorization", getJwt(user)))
+          .andReturn().getResponse().getStatus();
+
+      assertNotEquals(403, result, "Failed on " + user);
+      assertNotEquals(401, result, "Failed on " + user);
+    }
+
+    var result = mvc
+        .perform(
+            get(EndpointConstants.API_V_0_1_ACCOUNTS + "/new-password/potato"))
+        .andReturn().getResponse().getStatus();
+
+    assertNotEquals(403, result, "Failed on no authorization");
+    assertNotEquals(401, result, "Failed on no authorization");
+  }
+
+  @Test
+  void test_changePassword_AllowedByAny() throws Exception {
+    var alwaysAuthed = List.of(MockUser.ADMIN,
+                               MockUser.SERVICE,
+                               MockUser.EMPLOYEE,
+                               MockUser.TRAVEL_AGENT,
+                               MockUser.MATCH_CUSTOMER,
+                               MockUser.DEFAULT,
+                               MockUser.UNMATCH_CUSTOMER);
+    for (var user : alwaysAuthed) {
+      var result = mvc
+          .perform(
+              post(EndpointConstants.API_V_0_1_ACCOUNTS + "/new-password")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("")
+                  .header("Authorization", getJwt(user)))
+          .andReturn().getResponse().getStatus();
+
+      assertNotEquals(403, result, "Failed on " + user);
+      assertNotEquals(401, result, "Failed on " + user);
+    }
+
+    var result = mvc
+        .perform(
+            get(EndpointConstants.API_V_0_1_ACCOUNTS + "/new-password/potato")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(""))
+        .andReturn().getResponse().getStatus();
+
+    assertNotEquals(403, result, "Failed on no authorization");
+    assertNotEquals(401, result, "Failed on no authorization");
+  }
+
+  @Test
+  void test_deleteAccount_OnlyAllowedByAdmin() throws Exception {
+    var alwaysAuthed = List.of(MockUser.ADMIN);
+
+    for (var user : alwaysAuthed) {
+      var result = mvc
+          .perform(
+              delete(EndpointConstants.API_V_0_1_ACCOUNTS + "/" + UUID.randomUUID())
+                  .header("Authorization", getJwt(user)))
+          .andReturn().getResponse().getStatus();
+      assertNotEquals(403, result, "Failed on " + user);
+      assertNotEquals(401, result, "Failed on " + user);
+    }
+
+    var notauthed = List.of(MockUser.SERVICE,
+                            MockUser.EMPLOYEE,
+                            MockUser.TRAVEL_AGENT,
+                            MockUser.MATCH_CUSTOMER,
+                            MockUser.DEFAULT,
+                            MockUser.UNMATCH_CUSTOMER);
+    for (var user : notauthed) {
+      var result = mvc
+          .perform(
+              delete(EndpointConstants.API_V_0_1_ACCOUNTS + "/" + UUID.randomUUID())
+                  .header("Authorization", getJwt(user)))
+          .andReturn().getResponse().getStatus();
+
+      assertEquals(403, result, "Failed on " + user);
+    }
+    var result = mvc
+        .perform(
+            delete(EndpointConstants.API_V_0_1_ACCOUNTS + "/" + UUID.randomUUID()))
+        .andReturn().getResponse().getStatus();
+
+    assertEquals(403, result, "Failed on no authorization");
+  }
+
+  @Test
+  void test_initiateCustomerDeletion_OnlyAllowedByServiceOrAdmin() throws Exception {
+    var alwaysAuthed = List.of(MockUser.SERVICE, MockUser.ADMIN);
+
+    var content = new ObjectMapper().writeValueAsString(DeleteAccountDto.builder()
+                                                            .id(UUID.randomUUID())
+                                                            .email("whatever@test.com")
+                                                            .password("abCD1234!@")
+                                                            .build());
+
+    for (var user : alwaysAuthed) {
+      var result = mvc
+          .perform(
+              delete(EndpointConstants.API_V_0_1_ACCOUNTS + "/customer")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(content)
+                  .header("Authorization", getJwt(user)))
+          .andReturn().getResponse().getStatus();
+
+      assertEquals(204, result, "Failed on " + user);
+    }
+
+    var notauthed = List.of(MockUser.EMPLOYEE,
+                            MockUser.TRAVEL_AGENT,
+                            MockUser.MATCH_CUSTOMER,
+                            MockUser.DEFAULT,
+                            MockUser.UNMATCH_CUSTOMER);
+    for (var user : notauthed) {
+      var result = mvc
+          .perform(
+              delete(EndpointConstants.API_V_0_1_ACCOUNTS + "/customer")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(content)
+                  .header("Authorization", getJwt(user)))
+          .andReturn().getResponse().getStatus();
+
+      assertEquals(403, result, "Failed on " + user);
+    }
+    var result = mvc
+        .perform(
+            delete(EndpointConstants.API_V_0_1_ACCOUNTS + "/customer")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content))
+        .andReturn().getResponse().getStatus();
+
+    assertEquals(403, result, "Failed on no authorization");
+  }
+
+  @Test
+  void test_completeCustomerDeletion_OnlyAllowedByServiceOrAdmin() throws Exception {
+    var alwaysAuthed = List.of(MockUser.SERVICE, MockUser.ADMIN);
+
+    var content = new ObjectMapper().writeValueAsString(DeleteAccountDto.builder()
+                                                            .id(UUID.randomUUID())
+                                                            .email("whatever@test.com")
+                                                            .password("abCD1234!@")
+                                                            .build());
+
+    for (var user : alwaysAuthed) {
+      var result = mvc
+          .perform(
+              delete(EndpointConstants.API_V_0_1_ACCOUNTS + "/customer/confirm")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(content)
+                  .header("Authorization", getJwt(user)))
+          .andReturn().getResponse().getStatus();
+      assertNotEquals(403, result, "Failed on " + user);
+      assertNotEquals(401, result, "Failed on " + user);
+    }
+
+    var notauthed = List.of(MockUser.EMPLOYEE,
+                            MockUser.TRAVEL_AGENT,
+                            MockUser.MATCH_CUSTOMER,
+                            MockUser.DEFAULT,
+                            MockUser.UNMATCH_CUSTOMER);
+    for (var user : notauthed) {
+      var result = mvc
+          .perform(
+              delete(EndpointConstants.API_V_0_1_ACCOUNTS + "/customer/confirm")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(content)
+                  .header("Authorization", getJwt(user)))
+          .andReturn().getResponse().getStatus();
+
+      assertEquals(403, result, "Failed on " + user);
+    }
+    var result = mvc
+        .perform(
+            delete(EndpointConstants.API_V_0_1_ACCOUNTS + "/customer/confirm")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content))
+        .andReturn().getResponse().getStatus();
+
+    assertEquals(403, result, "Failed on no authorization");
+  }
+
+  enum MockUser {
+    DEFAULT("default@test.com", "ROLE_DEFAULT", UUID.randomUUID().toString()),
+    MATCH_CUSTOMER("eddy_grant@test.com", "ROLE_CUSTOMER", "a4a9feca-bfe7-4c45-8319-7cb6cdd359db"),
+    UNMATCH_CUSTOMER("someOtherCustomer@test.com", "ROLE_CUSTOMER", UUID.randomUUID().toString()),
+    EMPLOYEE("employee@test.com", "ROLE_EMPLOYEE", UUID.randomUUID().toString()),
+    TRAVEL_AGENT("travel_agent@test.com", "ROLE_TRAVEL_AGENT", UUID.randomUUID().toString()),
+    SERVICE("service@test.com", "ROLE_SERVICE", UUID.randomUUID().toString()),
+    ADMIN("admin@test.com", "ROLE_ADMIN", UUID.randomUUID().toString());
+
+
+    final String email;
+    final GrantedAuthority grantedAuthority;
+    final String id;
+
+    MockUser(String email, String grantedAuthority, String id) {
+      this.email = email;
+      this.grantedAuthority = new SimpleGrantedAuthority(grantedAuthority);
+      this.id = id;
+    }
+
+    public String getAuthority() {
+      return grantedAuthority.getAuthority();
+    }
+  }
+}

--- a/src/test/java/com/ss/utopia/auth/service/AccountActionTokenServiceImplTests.java
+++ b/src/test/java/com/ss/utopia/auth/service/AccountActionTokenServiceImplTests.java
@@ -1,0 +1,107 @@
+package com.ss.utopia.auth.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.ss.utopia.auth.entity.AccountAction;
+import com.ss.utopia.auth.entity.AccountActionToken;
+import com.ss.utopia.auth.exception.InvalidTokenException;
+import com.ss.utopia.auth.exception.NoSuchAccountActionToken;
+import com.ss.utopia.auth.repository.AccountActionTokenRepository;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class AccountActionTokenServiceImplTests {
+
+  AccountActionTokenRepository accountActionTokenRepository =
+      Mockito.mock(AccountActionTokenRepository.class);
+
+  AccountActionTokenService service =
+      new AccountActionTokenServiceImpl(accountActionTokenRepository);
+
+  ZonedDateTime tokenCreation = ZonedDateTime.now();
+
+  AccountActionToken mockValidConfirmationToken = AccountActionToken.builder()
+      .token(UUID.randomUUID())
+      .ownerAccountId(UUID.randomUUID())
+      .active(true)
+      .action(AccountAction.CONFIRMATION)
+      .creation(tokenCreation)
+      .build();
+
+  AccountActionToken mockInactiveConfirmationToken = AccountActionToken.builder()
+      .token(mockValidConfirmationToken.getToken())
+      .ownerAccountId(UUID.randomUUID())
+      .active(false)
+      .action(AccountAction.CONFIRMATION)
+      .creation(tokenCreation)
+      .build();
+
+  AccountActionToken mockExpiredConfirmationToken = AccountActionToken.builder()
+      .token(mockValidConfirmationToken.getToken())
+      .ownerAccountId(UUID.randomUUID())
+      .active(false)
+      .action(AccountAction.CONFIRMATION)
+      .creation(tokenCreation.minusMinutes(AccountAction.CONFIRMATION.getMinutesToLive() + 1))
+      .build();
+
+  @BeforeEach
+  void beforeEach() {
+    Mockito.reset(accountActionTokenRepository);
+  }
+
+  @Test
+  void test_getToken_ReturnsExpectedToken() {
+    when(accountActionTokenRepository.findById(mockValidConfirmationToken.getToken()))
+        .thenReturn(Optional.of(mockValidConfirmationToken));
+
+    var result = service.getToken(mockValidConfirmationToken.getToken());
+
+    assertEquals(mockValidConfirmationToken, result);
+  }
+
+  @Test
+  void test_getToken_ThrowsNoSuchAccountActionTokenOnNotFound() {
+    when(accountActionTokenRepository.findById(any()))
+        .thenReturn(Optional.empty());
+
+    assertThrows(NoSuchAccountActionToken.class,
+                 () -> service.getToken(mockValidConfirmationToken.getToken()));
+  }
+
+  @Test
+  void test_validateToken_DoesNotThrowExceptionOnValidToken() {
+    assertDoesNotThrow(() -> service.validateToken(mockValidConfirmationToken));
+  }
+
+  @Test
+  void test_validateToken_ThrowsInvalidTokenExceptionOnInactiveToken() {
+    when(accountActionTokenRepository.findById(any()))
+        .thenReturn(Optional.of(mockInactiveConfirmationToken));
+
+    assertThrows(InvalidTokenException.class,
+                 () -> service.validateToken(mockInactiveConfirmationToken));
+
+    assertThrows(InvalidTokenException.class,
+                 () -> service.getAndValidateToken(mockInactiveConfirmationToken.getToken()));
+  }
+
+  @Test
+  void test_validateToken_ThrowsInvalidTokenExceptionOnExpiredToken() {
+    when(accountActionTokenRepository.findById(any()))
+        .thenReturn(Optional.of(mockExpiredConfirmationToken));
+
+    assertThrows(InvalidTokenException.class,
+                 () -> service.validateToken(mockExpiredConfirmationToken));
+
+    assertThrows(InvalidTokenException.class,
+                 () -> service.getAndValidateToken(mockExpiredConfirmationToken.getToken()));
+  }
+}


### PR DESCRIPTION
Add Service account for method preauthorization to allow services specific
permission to initiate and confirm account deletion.
Enable preauthorization for methods in security configuration.
Add permission annotations for admin and service roles.
Add methods to controller to initiate and confirm account deletion.
Add DeleteAccountEmail for confirming deletion.
Update EmailClient with method for sending deletion confirmation.
Refactor AccountActionTokens to be handled by a specific service for
code deduplication.
Add unit tests to all above changes.