### PR TITLE
SSUTO-9 FEAT: User Account Deletion

### DIFF
--- a/src/main/java/com/ss/utopia/auth/bootstrap/H2DataBootstrap.java
+++ b/src/main/java/com/ss/utopia/auth/bootstrap/H2DataBootstrap.java
@@ -31,6 +31,7 @@ public class H2DataBootstrap implements CommandLineRunner {
     loadCustomerUser();
     loadTravelAgentUser();
     loadEmployeeUser();
+    loadServiceUser();
     loadAdminUser();
   }
 
@@ -68,6 +69,16 @@ public class H2DataBootstrap implements CommandLineRunner {
         .email("employee@test.com")
         .password(encodedPassword)
         .userRole(UserRole.EMPLOYEE)
+        .confirmed(true)
+        .build();
+    userAccountRepository.save(user);
+  }
+
+  private void loadServiceUser() {
+    var user = UserAccount.builder()
+        .email("service@test.com")
+        .password(encodedPassword)
+        .userRole(UserRole.SERVICE)
         .confirmed(true)
         .build();
     userAccountRepository.save(user);

--- a/src/main/java/com/ss/utopia/auth/controller/UserAccountController.java
+++ b/src/main/java/com/ss/utopia/auth/controller/UserAccountController.java
@@ -106,9 +106,9 @@ public class UserAccountController {
   }
 
   @ServiceOnlyPermission
-  @DeleteMapping("/customer/confirm")
-  public ResponseEntity<UUID> completeCustomerDeletion(@Valid @RequestBody DeleteAccountDto deleteAccountDto) {
-    var accountId = userAccountService.completeCustomerDeletion(deleteAccountDto);
+  @DeleteMapping("/customer/{confirmationToken}")
+  public ResponseEntity<UUID> completeCustomerDeletion(@PathVariable UUID confirmationToken) {
+    var accountId = userAccountService.completeCustomerDeletion(confirmationToken);
     return ResponseEntity.ok(accountId);
   }
 }

--- a/src/main/java/com/ss/utopia/auth/dto/AuthResponse.java
+++ b/src/main/java/com/ss/utopia/auth/dto/AuthResponse.java
@@ -1,5 +1,6 @@
 package com.ss.utopia.auth.dto;
 
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class AuthResponse {
+  private UUID userId;
   private String token;
   private long expiresAt;
 }

--- a/src/main/java/com/ss/utopia/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ss/utopia/auth/security/JwtAuthenticationFilter.java
@@ -94,7 +94,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     log.debug("Created JWT: " + jwt);
 
     var respBody = objectMapper
-        .writeValueAsString(new AuthResponse(headerVal, expiresAt.getTime()));
+        .writeValueAsString(new AuthResponse(id, headerVal, expiresAt.getTime()));
 
     response.addHeader(securityConstants.getJwtHeaderName(), headerVal);
     response.getWriter().write(respBody);

--- a/src/main/java/com/ss/utopia/auth/service/AccountActionTokenServiceImpl.java
+++ b/src/main/java/com/ss/utopia/auth/service/AccountActionTokenServiceImpl.java
@@ -8,8 +8,10 @@ import com.ss.utopia.auth.repository.AccountActionTokenRepository;
 import java.time.ZonedDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AccountActionTokenServiceImpl implements AccountActionTokenService {
@@ -18,6 +20,7 @@ public class AccountActionTokenServiceImpl implements AccountActionTokenService 
 
   @Override
   public AccountActionToken getToken(UUID token) {
+    log.debug("Get token=" + token);
     return accountActionTokenRepository.findById(token)
         .orElseThrow(() -> new NoSuchAccountActionToken(token));
   }
@@ -35,6 +38,7 @@ public class AccountActionTokenServiceImpl implements AccountActionTokenService 
 
   @Override
   public AccountActionToken createToken(UUID ownerId, AccountAction action) {
+    log.debug("Create token, owner=" + ownerId + " action=" + action);
     return accountActionTokenRepository.save(AccountActionToken.builder()
                                                  .ownerAccountId(ownerId)
                                                  .action(action)
@@ -48,6 +52,7 @@ public class AccountActionTokenServiceImpl implements AccountActionTokenService 
 
   @Override
   public void deleteToken(UUID tokenId) {
+    log.debug("Delete token=" + tokenId);
     accountActionTokenRepository.findById(tokenId)
         .ifPresent(accountActionTokenRepository::delete);
   }

--- a/src/main/java/com/ss/utopia/auth/service/UserAccountService.java
+++ b/src/main/java/com/ss/utopia/auth/service/UserAccountService.java
@@ -28,5 +28,5 @@ public interface UserAccountService {
 
   void initiateCustomerDeletion(DeleteAccountDto deleteAccountDto);
 
-  UUID completeCustomerDeletion(DeleteAccountDto deleteAccountDto);
+  UUID completeCustomerDeletion(UUID confirmationToken);
 }

--- a/src/main/java/com/ss/utopia/auth/service/UserAccountServiceImpl.java
+++ b/src/main/java/com/ss/utopia/auth/service/UserAccountServiceImpl.java
@@ -137,17 +137,16 @@ public class UserAccountServiceImpl implements UserAccountService {
   }
 
   @Override
-  public UUID completeCustomerDeletion(DeleteAccountDto deleteAccountDto) {
-    authenticate(deleteAccountDto);
-
-    var actionToken = accountActionTokenService.getAndValidateToken(deleteAccountDto.getId());
-    var account = getByEmail(deleteAccountDto.getEmail());
+  public UUID completeCustomerDeletion(UUID confirmationToken) {
+    var actionToken = accountActionTokenService.getAndValidateToken(confirmationToken);
+    var ownerId = actionToken.getOwnerAccountId();
+    var account = getById(ownerId);
 
     if (!isCustomerOrDefault(account)) {
       throw new IllegalCustomerAccountDeletionException(account);
     }
 
-    deleteAccountByEmail(deleteAccountDto.getEmail());
+    deleteAccountById(ownerId);
     accountActionTokenService.deleteToken(actionToken);
     return account.getId();
   }

--- a/src/main/java/com/ss/utopia/auth/service/UserAccountServiceImpl.java
+++ b/src/main/java/com/ss/utopia/auth/service/UserAccountServiceImpl.java
@@ -63,8 +63,8 @@ public class UserAccountServiceImpl implements UserAccountService {
   @Override
   @Transactional(rollbackFor = EmailNotSentException.class)
   public UserAccount createNewAccount(CreateUserAccountDto createUserAccountDto) {
-    log.debug("Create new account email=" + createUserAccountDto.getEmail());
     validateDto(createUserAccountDto);
+    log.debug("Create new account email=" + createUserAccountDto.getEmail());
 
     userAccountRepository.findByEmail(createUserAccountDto.getEmail())
         .ifPresent(userAccount -> {

--- a/src/test/java/com/ss/utopia/auth/controller/UserAccountControllerSecurityTests.java
+++ b/src/test/java/com/ss/utopia/auth/controller/UserAccountControllerSecurityTests.java
@@ -364,12 +364,12 @@ public class UserAccountControllerSecurityTests {
                                                             .password("abCD1234!@")
                                                             .build());
 
+    var url = EndpointConstants.API_V_0_1_ACCOUNTS + "/customer/" + UUID.randomUUID();
+
     for (var user : alwaysAuthed) {
       var result = mvc
           .perform(
-              delete(EndpointConstants.API_V_0_1_ACCOUNTS + "/customer/confirm")
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(content)
+              delete(url)
                   .header("Authorization", getJwt(user)))
           .andReturn().getResponse().getStatus();
       assertNotEquals(403, result, "Failed on " + user);
@@ -384,9 +384,7 @@ public class UserAccountControllerSecurityTests {
     for (var user : notauthed) {
       var result = mvc
           .perform(
-              delete(EndpointConstants.API_V_0_1_ACCOUNTS + "/customer/confirm")
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(content)
+              delete(url)
                   .header("Authorization", getJwt(user)))
           .andReturn().getResponse().getStatus();
 
@@ -394,9 +392,7 @@ public class UserAccountControllerSecurityTests {
     }
     var result = mvc
         .perform(
-            delete(EndpointConstants.API_V_0_1_ACCOUNTS + "/customer/confirm")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(content))
+            delete(url))
         .andReturn().getResponse().getStatus();
 
     assertEquals(403, result, "Failed on no authorization");

--- a/src/test/java/com/ss/utopia/auth/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/ss/utopia/auth/security/JwtAuthenticationFilterTest.java
@@ -3,7 +3,6 @@ package com.ss.utopia.auth.security;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import com.auth0.jwt.JWT;
@@ -18,7 +17,6 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.util.Collections;
 import java.util.Date;
-import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.servlet.FilterChain;
@@ -158,7 +156,6 @@ class JwtAuthenticationFilterTest {
 
     when(mockAuthResult.getName()).thenReturn(mockAuthDto.getEmail());
 
-
     when(mockAuthResult.getPrincipal()).thenReturn(mockUserAccount);
 
     var mockAuthorities = mockUserAccount.getAuthorities()
@@ -176,8 +173,9 @@ class JwtAuthenticationFilterTest {
 
     var spyResponse = Mockito.spy(mockResponse);
 
-    var expectedAuthResponse = new AuthResponse(
-        "Bearer " + expectedJwt, mockSecurityConstants.getExpiresAt().getTime());
+    var expectedAuthResponse = new AuthResponse(mockUserAccount.getId(),
+                                                "Bearer " + expectedJwt,
+                                                mockSecurityConstants.getExpiresAt().getTime());
 
     var expectedAuthResponseAsJson = new ObjectMapper()
         .writeValueAsString(expectedAuthResponse);
@@ -212,8 +210,4 @@ class JwtAuthenticationFilterTest {
     Mockito.verify(spyResponse).addHeader("Authorization", "Bearer " + expectedJwt);
   }
 
-  @Test
-  void bcrypt() {
-    System.out.println(new BCryptPasswordEncoder().encode("test"));
-  }
 }


### PR DESCRIPTION
Provides API for deleting a UserAccount that belongs to a customer. Process involves first initiating a request and sending a confirmation email with a token. Confirming with this token will remove the account from persistence and return the ID of the removed account.