### PR TITLE
SSUTO-86 TASK: Deprecate Eureka Service Discovery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,11 +40,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
@@ -116,7 +111,14 @@
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-maven-plugin</artifactId>
       <version>${spotbugs.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-simple</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+
   </dependencies>
 
   <dependencyManagement>

--- a/src/main/java/com/ss/utopia/auth/UtopiaAuthServiceApplication.java
+++ b/src/main/java/com/ss/utopia/auth/UtopiaAuthServiceApplication.java
@@ -1,13 +1,8 @@
 package com.ss.utopia.auth;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.commons.util.InetUtils;
-import org.springframework.cloud.netflix.eureka.EurekaInstanceConfigBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @SpringBootApplication
@@ -20,16 +15,5 @@ public class UtopiaAuthServiceApplication {
   @Bean
   public BCryptPasswordEncoder passwordEncoder() {
     return new BCryptPasswordEncoder();
-  }
-
-  @Profile("ecs")
-  @Bean
-  public EurekaInstanceConfigBean eurekaInstanceConfigBean(InetUtils inetUtils)
-      throws UnknownHostException {
-    var config = new EurekaInstanceConfigBean(inetUtils);
-    config.setIpAddress(InetAddress.getLocalHost().getHostAddress());
-    config.setNonSecurePort(8089);
-    config.setPreferIpAddress(true);
-    return config;
   }
 }

--- a/src/main/resources/application-ecs.properties
+++ b/src/main/resources/application-ecs.properties
@@ -1,0 +1,2 @@
+spring.config.import=configserver:
+spring.cloud.config.uri=http://utopia-config-service:8888

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,2 @@
+spring.config.import=configserver:
+spring.cloud.config.uri=http://localhost:8888

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,3 @@
 spring.application.name=utopia-auth-service
 
-# require configuration from service through Eureka discovery
-spring.config.import=configserver:
-spring.cloud.config.discovery.enabled=true
-spring.cloud.config.discovery.service-id=utopia-config-service
-
 spring.profiles.active=local,local-h2


### PR DESCRIPTION
This change commits to using service discovery created by Docker Compose
for ECS deployments. For local development, no service discovery will be
necessary. Instead, we are providing an additional `local` profile for
interacting with the configuration server. As such, the Eureka dependency
has been removed, and the `ecs` profile Bean for handling Eureka has been
removed.

This additionally excludes SLF4J bindings from the SpotBugs dependency
which was causing a warning on application boot.